### PR TITLE
Add filter for CSS media type

### DIFF
--- a/grid-columns.php
+++ b/grid-columns.php
@@ -135,7 +135,8 @@ class Grid_Columns {
 			'grid-columns',
 			trailingslashit( plugin_dir_url( __FILE__ ) ) . "css/columns$suffix.css",
 			null,
-			'20130123'
+			'20130123',
+			apply_filters('gc_css_media_type', 'all')
 		);
 	}
 


### PR DESCRIPTION
Could you add filter for CSS media type? It could make easier to exclude default column CSS in specific screen sizes, for example when you are designing responsive theme. Nobody wants to read 100px width columns in their mobile screens.

Example usage of the filter:
`add_filter('gc_css_media_type', function(){
    return '(min-width:480px)';
});
`
